### PR TITLE
better command injection fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const getNpmPkgVersion = function (packageName, { registry = '', timeout = null } = {}) {
   try {
-    if (/[`$&{}[;|]/g.test(packageName) || /[`$&{}[;|]/g.test(registry)) {
+    if (/[`$&{}[;|<>#\n \t()]/g.test(packageName) || /[`$&{}[;|<>#\n \t()]/g.test(registry)) {
       return null;
     }
     let version;


### PR DESCRIPTION
The first fix wasn't good enough (https://github.com/hoperyy/get-npm-package-version/pull/1).  

The following attack string could bypass the fix: `"test #\ntouch pwned"`.

/cc @DuLinRain 